### PR TITLE
Multiple plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ produces
       0     1    2     3     4     5    6     7
 ```
 
+#### Multiple plots
+
+If y is a tuple, list, or numpy array, multiple graphs will be displayed in the one plot.
+
+#### Colors
+
+Passing plot() gnuplot_term_arguments='ansi', or 'ansi256', etc. will provide color output if your terminal supports it. Gnuplot defaults to 'mono'.
+
 ### Horizontal histograms
 
 ```python

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,2 @@
+import setuptools
+setuptools.setup()

--- a/termplotlib/plot.py
+++ b/termplotlib/plot.py
@@ -2,9 +2,6 @@ import subprocess
 import numpy as np
 import ipdb as pdb
 
-def is_litup(v):
-    return (type(v) is list or type(v) is tuple)
-
 def is_array(v):
     return (type(v) is list or type(v) is np.ndarray or type(v) is tuple)
 


### PR DESCRIPTION
This change is a modification to plot() to allow multiple graphs in a single plot (overlapping).  It uses the single x-axis range as before, however.

Currently, it examines y to see if it's a multidimensional list and will prepare the data accordingly (blank-line-separated heredoc).  Since I also added support for the dumb terminal options (up to the user), like 'ansi', I had to change the way the heredoc was presented to gnuplot.  (using $data <<EOD).  Without this, multiple plots still works, but gnuplot could not automatically color them differently.

