### PR TITLE
Integration with rich

### DIFF
--- a/termplotlib/figure.py
+++ b/termplotlib/figure.py
@@ -16,6 +16,9 @@ class Figure:
         self._padding = create_padding_tuple(padding)
         return
 
+    def __rich_console__(self, *args):
+        yield self.get_string()
+
     def aprint(self, string):
         self._content.append(string.split("\n"))
         return


### PR DESCRIPTION
As discussed: https://github.com/willmcgugan/rich/discussions/1002

Added a `__rich_console__` method to `Figure` for integration with rich.
This simplifies the syntax when displaying plots in rich, and enables for simple formatting (e.g. color of string representation of the plots)