### PR TITLE
Attempted fix for barh integer type check

### DIFF
--- a/src/termplotlib/barh.py
+++ b/src/termplotlib/barh.py
@@ -1,5 +1,7 @@
 from typing import List
 
+import numpy
+
 from .helpers import is_unicode_standard_output
 
 
@@ -28,7 +30,7 @@ def barh(
         fmt.append(cfmt)
 
     if show_vals:
-        all_int = all(isinstance(val, int) for val in vals)
+        all_int = all(isinstance(val, (int, numpy.integer)) for val in vals)
         if all_int:
             cfmt = "{{:{}d}}".format(max([len(str(val)) for val in vals]))
         else:

--- a/src/termplotlib/barh.py
+++ b/src/termplotlib/barh.py
@@ -28,7 +28,7 @@ def barh(
         fmt.append(cfmt)
 
     if show_vals:
-        all_int = all(val == int(val) for val in vals)
+        all_int = all(isinstance(val, int) for val in vals)
         if all_int:
             cfmt = "{{:{}d}}".format(max([len(str(val)) for val in vals]))
         else:


### PR DESCRIPTION
I am running into the same ValueError for what was reported at the top of #27. The barh function has worked for float values except when all included float values are equal to their rounded values (e.g., 1.0, 12.0). I found this integer type check which I believe is the source of the issue. After changing this line and testing it very briefly, it no longer seems to be an issue. 